### PR TITLE
Remove type validation for perrt_consult_datetime

### DIFF
--- a/models/src/models/perrt.py
+++ b/models/src/models/perrt.py
@@ -25,7 +25,7 @@ class PerrtRaw(BaseModel):
     dept_name: str
     room_name: str
     bed_hl7: str
-    perrt_consult_datetime: Optional[datetime]
+    perrt_consult_datetime: object
     # observation level fields
     visit_observation_id: int
     hospital_visit_id: str
@@ -105,7 +105,7 @@ class PerrtBase(BaseModel):
     dept_name: str
     room_name: str
     bed_hl7: str
-    perrt_consult_datetime: Optional[datetime]
+    perrt_consult_datetime: object
     # observation level fields collapsed to per patient
     air_or_o2_max: Optional[float]
     air_or_o2_min: Optional[float]


### PR DESCRIPTION
This isn't solving the issue but I haven't had a chance to fight with the type system long enough to work out what it wants. The perrt_consult_datetime can be null, despite the field being marked as optional it will still try to pass the null/None type into the datetime constructor, which throws an error as it's not a valid number. I tried adding cases to the validator function which is already there, didn't seem to work.

This needs a better solution, but as the dashboard is currently entirely broken with nothing displaying, I'd like to push this to hold us over for now