### PR TITLE
setup for running pytest in live environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Test with pytest
         working-directory: ./
         # Ideally we should not need all the environment variables to test.
-        run: pytest
+        run: pytest -m "not live"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -30,3 +30,7 @@ minversion = "7.1.3"
 testpaths = [
     "src/api/tests"
 ]
+markers = [
+    "smoke: subset of tests",
+    "live: tests that should only run in the live environment"
+]

--- a/api/src/api/tests/test_demo.py
+++ b/api/src/api/tests/test_demo.py
@@ -1,0 +1,33 @@
+import pytest
+
+from api.main import app
+from fastapi.testclient import TestClient
+
+from models.demo import ClarityOrCase
+
+client = TestClient(app)
+
+
+def test_get_mock_demo():
+    response = client.get("/mock/demo/", params={})
+    assert response.status_code == 200
+
+    demo_rows = [ClarityOrCase.parse_obj(row) for row in response.json()]
+    assert len(demo_rows) > 0
+
+
+@pytest.mark.live
+def test_get_demo():
+    """
+    Should only pass when run in the live environment hence the marker
+    i.e. when developing locally
+    `pytest -v -m 'not live'`
+
+    Should not fail - would suggest no operating in the next 3 days
+    :return:
+    """
+    response = client.get("/demo/", params={"days_ahead": 3})
+    assert response.status_code == 200
+
+    demo_rows = [ClarityOrCase.parse_obj(row) for row in response.json()]
+    assert len(demo_rows) > 0

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -35,7 +35,10 @@ COPY --chown=hyui:root ./models/pyproject.toml /app/models/
 RUN pip install --no-cache-dir /app/models
 
 COPY --chown=hyui:root ./api/pyproject.toml /app/api/
-RUN pip install --no-cache-dir /app/api
+# installs testing: useful for debugging
+RUN pip install --no-cache-dir /app/api[test]
+# without testing
+#RUN pip install --no-cache-dir /app/api
 
 COPY --chown=hyui:root ./models/src/models /app/models
 COPY --chown=hyui:root ./api/src/api /app/api

--- a/docs/developer/deployment.qmd
+++ b/docs/developer/deployment.qmd
@@ -33,3 +33,11 @@ docker compose --project-name [project name] up
 ```sh
 docker compose --project-name [project name] down
 ```
+
+### An one-liner
+
+Replace _myname_ with anything that won't clash with other users (e.g. _your_ name!)
+
+```shell
+docker compose --project-name hyui-dev-myname up --build -d && docker compose -p hyui-dev-myname logs -f
+```

--- a/docs/developer/pycharm.qmd
+++ b/docs/developer/pycharm.qmd
@@ -1,0 +1,27 @@
+Notes on setting up PyCharm for development with specific reference to working on a Mac
+
+## Tips
+
+Set up run configurations
+
+- https://www.jetbrains.com/help/pycharm/run-debug-configuration.html
+- install the **EnvFile** plug-in so that the environment file can be read by your run configuration (see https://stackoverflow.com/a/42708476/992999)
+- set `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` as an environment variable in your run configuration to avoid [errors](https://stackoverflow.com/a/52230415/992999) on recent _macos_ installs
+- consider also specifying a 'pytest' configuration where you can store the arguments to prevent pytest running those tests that should only run in the live environment (assuming that you are developing locally)
+
+e.g. where you have decorated your test function
+
+```python
+@pytest.mark.live
+def test_get_demo():
+    response = client.get("/demo/", params={"days_ahead": 3})
+    assert response.status_code == 200
+```
+
+```shell
+pytest -v -m 'not live'
+```
+
+Example configurations here
+- [FastAPI](../snippets/HyUI-API%20FastAPI.run.xml)
+- [Plotly Dash](../snippets/HyUI-Web%20Plotly%20Dash.run.xml)

--- a/docs/developer/setup.qmd
+++ b/docs/developer/setup.qmd
@@ -104,14 +104,23 @@ Ensure you replace `.env` with the correct path to your development `.env` file.
 Sometimes it can be difficult to debug your staging services from within the NHS's firewall on live data. You can log into the `hyui-web` or `hyui-api` services from a terminal within the `HyUi` directory using the following:
 
 ```sh
-docker compose --project-name [project name] exec hyui-web bash
+docker compose --project-name [project name] exec web bash
 ```
 
 ```sh
-docker compose --project-name [project name] exec hyui-api bash
+docker compose --project-name [project name] exec api bash
 ```
 
 You can then change the code using vim or open a python console and debug from there. It may be useful to edit the `docker/api/Dockerfile` or `docker/web/Dockerfile` and add a `--reload` flag to the `ENTRYPOINT` so that code changes from within the container are reloaded automatically. `ENTRYPOINT ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--reload"]` instead of `ENTRYPOINT ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--reload"]`.
+You can also run `pytest` from within the docker container (if the `pip install` step enables the additonal options in the `pyproject.toml` file)
+
+e.g.
+```Dockerfile
+# without testing: standard set-up
+#RUN pip install --no-cache-dir /app/api
+# installs testing: useful for debugging
+RUN pip install --no-cache-dir /app/api[test]
+```
 
 If you prefer not to use vim then Visual Studio can SSH into the running containers somehow.
 


### PR DESCRIPTION
see #161 (although this issue could be better named) 

force pytest installation
notes on debugging live from the GAE
distinguish tests for the live environment
filter live tests out of CI

Note from @jongillham 

> I see the idea here. However I'm not so keen on unit tests that need external dependencies such as a live system to work. It potentially sets a bad precedent for future tests.
> 
> I also see the consequence of this test is that by default pyenv now needs -m 'not live' where as ideally testing live should be the exception.
> 
> I would prefer that you ripped out the live testing part and we figure out another way to do integration testing on the live or staging deployments.
> 

@harryjmoss & @docsteveharris what are your thoughts on how strict with codebase we should be?
