### PR TITLE
Fixing bad config for cache use on the hospital network

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 x-http-proxy: &http-proxy ${HTTP_PROXY}
 x-https-proxy: &https-proxy ${HTTPS_PROXY}
-x-no-proxy: &no-proxy localhost,127.0.0.1,uclvlddpragae07,uclvlddpragae08,api,web,baserow
+x-no-proxy: &no-proxy localhost,127.0.0.1,uclvlddpragae07,uclvlddpragae08,api,web,cache,baserow
 
 x-proxy-common: &proxy-common
   HTTP_PROXY: *http-proxy


### PR DESCRIPTION
One-liner to make the cache accessible from `web` and `api` on the hospital network