### PR TITLE
Edits to setup + deployment docs

### DIFF
--- a/docs/developer/deployment.qmd
+++ b/docs/developer/deployment.qmd
@@ -70,3 +70,25 @@ To be used when updating an existing instance of baserow adjustments to default 
 ```sh
 docker compose --project-name [project name] down
 ```
+## Tips and Tricks
+### Debugging from within the NHS network
+
+Sometimes it can be difficult to debug your staging services when they are deployed via docker.
+
+You can log into the `hyui-web` or `hyui-api` services from a terminal within the `HyUi` directory using the following:
+
+```sh
+docker compose --project-name [project name] exec web bash
+```
+
+```sh
+docker compose --project-name [project name] exec api bash
+```
+
+You can then change the code using vim or open a python console and debug from there.
+
+Remember you will then need to manually make the same changes outside the docker bash terminal!
+
+It may be useful to edit the `docker/api/Dockerfile` or `docker/web/Dockerfile` and add a `--reload` flag to the `ENTRYPOINT` so that code changes from within the container are reloaded automatically. `ENTRYPOINT ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--reload"]` instead of `ENTRYPOINT ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--reload"]`.
+
+If you prefer not to use vim then Visual Studio can SSH into the running containers somehow.

--- a/docs/developer/ide_setup.qmd
+++ b/docs/developer/ide_setup.qmd
@@ -14,6 +14,7 @@ Example configurations here
 - [FastAPI](../snippets/HyUI-API%20FastAPI.run.xml)
 - [Plotly Dash](../snippets/HyUI-Web%20Plotly%20Dash.run.xml)
 
+If you are using PyCharm or another IDE then ensure that the environment variables in `.env` are loaded. PyCharm has a plugin that can load these when unit testing with `pytest` or running the main application.
 
 ## Notes on setting up VSCode for development
 
@@ -68,11 +69,11 @@ And my sidebar in VS Code (with the `web` labelled as 'HyUI Plotly Dash')
 
 ![](../resources/vscode-workspace-sidebar.png){width=50%}
 
-5. Then prepare nested `.vscode/settings.json` and `.vscode/launch.json` files etc (also visible in the screenshot above). For example, for the `web` module, you need to specify the interpreter, and a debug configuration (in `launch.json`)
+5. Then prepare nested `.vscode/settings.json` and `.vscode/launch.json` files etc (also visible in the screenshot above). For example, for the `web` module, you need to specify the interpreter, and a debug configuration (in `launch.json`).
 
 Beware the absolute paths below ☹. You will need to change these unless your name is also 'steve'.
 
-`settings.json`
+`settings.json`:
 
 ```json
 {
@@ -86,13 +87,10 @@ Beware the absolute paths below ☹. You will need to change these unless your n
 }
 ```
 
-`launch.json`
+`launch.json` under `web`:
 
 ```json
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
@@ -100,7 +98,9 @@ Beware the absolute paths below ☹. You will need to change these unless your n
             "type": "python",
             "request": "launch",
             "module": "web.app",
-            "args": [],
+            "args": [
+                "--reload"
+            ],
             "jinja": true,
             "justMyCode": true,
             "python": "/users/steve/.pyenv/versions/hyui-web/bin/python3",
@@ -114,3 +114,37 @@ Beware the absolute paths below ☹. You will need to change these unless your n
     ]
 }
 ```
+
+`launch.json` under `api`:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "hyui-api",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "api.main:app",
+                "--reload",
+                "--port",
+                "8092",
+            ],
+            "jinja": true,
+            "justMyCode": true,
+            "python": "/users/steve/.pyenv/versions/hyui-api/bin/python3",
+            "cwd": "${workspaceFolder}/src",
+            "envFile": "${workspaceFolder}/../.env",
+            "env": {
+                "OBJC_DISABLE_INITIALIZE_FORK_SAFETY": "YES",
+                "PYTHONUNBUFFERED": "1",
+            }
+        }
+    ]
+}
+```
+### Troubleshooting
+* Follow all the [setup](setup.qmd) instructions and check you can get everything running locally outside vscode first!
+* Check that the locations of python and your `.env` file are correct in your `launch.json` and `settings.json` file. You may need to write absolute paths in `settings.json` (even if `launch.json` uses the `{workSpaceFolder}` variables appropriately). For example, `"python.envFile": "~/Github/HyUi/.env"`).

--- a/docs/developer/setup.qmd
+++ b/docs/developer/setup.qmd
@@ -11,6 +11,7 @@ The root directory contains all the libraries that are used to power the HyUi da
 - `models`: This contains all the Pydantic models that are used to share data between the `api` and `web`.
 - `initialise`: This sets-up the BaseRow instance that is used for configuration by the user.
 - `cache`: This contains the HTTP cache service that serves cached objects from `api` to `web` with a 5 minute expiry. See [the deployment docs](./deployment.qmd) for more information.
+- `baserow`: We use [baserow](https://baserow.io) as a temporary database to that allows us to store information about patients without directly editing EMAP or EPIC. It is not relevant when running HyUI on your local machine, as all mock data will be stored locally. However, it is important to understand when [deploying](deployment.qmd) HyUI with live data within the NHS.
 
 ### Architecture Ideals
 - `web` should only communicate with `api` for data. This allows us to entirely mock data for `web` when developing.
@@ -18,27 +19,30 @@ The root directory contains all the libraries that are used to power the HyUi da
 - Pages in `web/src/web/pages` should be independent of each other so there is minimal/no sharing between two sets of pages. Common code can be put in a separate module or package in `web`.
 
 
-## Development
-
-Clone the HyUi repository to your local machine.
-
-```sh
-git clone https://github.com/HYLODE/HyUi.git
-```
+## Local Development
 
 ### Install Requirements
 
 - Install [https://github.com/pyenv/pyenv](pyenv)
 - Install [https://github.com/pyenv/pyenv-virtualenv](pyenv-virtualenv)
 
-### Create Required Virtual Environments
+
+### 1. Clone the HyUi repository to your local machine.
+
+```sh
+git clone https://github.com/HYLODE/HyUi.git
+```
+### 2. Create Required Virtual Environments
 
 ```sh
 pyenv virtualenv 3.11.0 hyui-web
 pyenv virtualenv 3.11.0 hyui-api
 ```
 
-### Activate Virtual Environment
+<span style="color:red">As of Feb 2023, Python 3.11.0 causes diskcache / SQLalchemy issues with local development on some machines. For now, we recommend changing the above commands to instead use python 3.10.8.</span>
+
+
+### 3. Activate Virtual Environments
 
 In one shell:
 
@@ -51,9 +55,9 @@ In another shell:
 pyenv activate hyui-api
 ```
 
-These will be the Python virtual environments that contains all the dependencies for the Dash web app and the API backend.
+These will be the Python virtual environments that contain all the dependencies for the Dash web app and the API backend.
 
-### Install the Website app requirements
+### 4. Install the Website app requirements
 
 In the `hyui-web` terminal in the root directory:
 
@@ -62,7 +66,7 @@ pip install -e "models[test]"
 pip install -e "web[test]"
 ```
 
-### Install the API requirements
+### 5. Install the API requirements
 In the `hyui-api` terminal in the root directory:
 
 ```sh
@@ -70,7 +74,7 @@ pip install -e "models[test]"
 pip install -e "api[test]"
 ```
 
-### Install The pre-commit Hooks
+### 6. Install the pre-commit Hooks
 
 In your shell (`hyui-api` or `hyui-web`) run the following command:
 
@@ -78,18 +82,22 @@ In your shell (`hyui-api` or `hyui-web`) run the following command:
 pre-commit install
 ```
 
-### Configuring Environment Variables
+### 6. Configure Environment Variables
 
-An example environment variable file can be found at `.env.example`. The environment variables for each app are documented in the Pydantic Settings classes in `web/src/web/config.py` and `api/src/api/config.py`. An important one for development and production is the `WEB_API_URL` variable. This should be set to the host and port of your `api` server so most likely something like `http://api:8000` for running in Docker or `http://localhost:[port]/mock` for development. Note that in development a `/mock` path has been added. This allows the Dash web app to use all the mock endpoints instead of the live endpoints.
+You will need to create and configure a `.env` file in your directory root.
+
+An example environment variable file can be found at `.env.example`. The environment variables for each app are documented in the Pydantic Settings classes in `web/src/web/config.py` and `api/src/api/config.py`. An important one for development and production is the `WEB_API_URL` variable. This should be set to the host and port of your `api` server so most likely something like `http://api:8000` for running in Docker or `http://localhost:[port]/mock` for development. The `port` needs to line up with that specified when starting the FastAPI server below (we have used `8092` throughout these docs).
+
+Note that in development a `/mock` path has been added. This allows the Dash web app to use all the mock endpoints instead of the live endpoints.
 
 The environment variables are _required_, and the application will fail if any of these are missing when it attempts to run.
 
-### Running The Servers Manually When Developing
+### 7. Running The Servers Manually When Developing
 
 The web server when in the `hyui-web` shell:
 
 ```sh
-env $(grep -v '^#' .env | xargs) python -m web.main
+env $(grep -v '^#' .env | xargs) python -m web.app
 ```
 
 The API server when in the `hyui-api` shell:
@@ -100,30 +108,18 @@ env $(grep -v '^#' .env | xargs) uvicorn api.main:app --reload --port 8092
 
 Ensure you replace `.env` with the correct path to your development `.env` file. The command `env $(grep -v '^#' .env | xargs)` loads the contents of the `.env` into the environment just for the current execution. The `grep -v '^#'` part excludes lines beginning with a `#` in the env file.
 
+The `--port` specified in the `hyui-api` command should match the port in the `WEB_API_URL` variable of your `.env`ironment.
 
-### Tips And Tricks
+You can run both these commands from within vscode or pycharm - see instructions [here](ide_setup.qmd).
 
-#### Debugging From Within The NHS Network
 
-Sometimes it can be difficult to debug your staging services from within the NHS's firewall on live data. You can log into the `hyui-web` or `hyui-api` services from a terminal within the `HyUi` directory using the following:
+## [Development within the NHS](deployment.qmd)
 
-```sh
-docker compose --project-name [project name] exec hyui-web bash
-```
+Further information on developing within the NHS found on the [Deployment](deployment.qmd) page.
 
-```sh
-docker compose --project-name [project name] exec hyui-api bash
-```
-
-You can then change the code using vim or open a python console and debug from there. It may be useful to edit the `docker/api/Dockerfile` or `docker/web/Dockerfile` and add a `--reload` flag to the `ENTRYPOINT` so that code changes from within the container are reloaded automatically. `ENTRYPOINT ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--reload"]` instead of `ENTRYPOINT ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--reload"]`.
-
-If you prefer not to use vim then Visual Studio can SSH into the running containers somehow.
-
+<!--
 
 #### Debugging On Your Local Machine
-
-If you are using PyCharm or another IDE then ensure that the environment variables in `.env` are loaded. PyCharm has a plugin that can load these when unit testing with `pytest` or running the main application.
-
 
 ## Initialisation
 
@@ -140,4 +136,4 @@ python -m initialise.main --operation baserow
 
 You can do this on your local machine but you need to install (with docker).
 See the [docs](https://baserow.io/docs/installation%2Finstall-with-docker).
-If you do this then don't forget to adjust the `BASEROW_PUBLIC_URL` to point to your local dev version (e.g. `http://localhost:80`)
+If you do this then don't forget to adjust the `BASEROW_PUBLIC_URL` to point to your local dev version (e.g. `http://localhost:80`) -->


### PR DESCRIPTION
I had found the "setup" and "deployment" pages a bit confusing. I have moved the tips and tricks for debugging from within the NHS network to the "deployment" page. 

My understanding was that baserow initialisation was not necessary for local development so I have moved it to the NHS development page as well. 

I have also added a warning regarding the python 3.11.0 issues - just because it tripped up me + Sarah + Lawrence over the past few days on our machines. 