### PR TITLE
Deleting Dark Mode

### DIFF
--- a/web/src/web/layout/appshell.py
+++ b/web/src/web/layout/appshell.py
@@ -32,7 +32,7 @@ def create_appshell(nav_data: list | dict) -> dmc.MantineProvider:
                     interval=6 * 60 * 60 * 1000,
                 ),
                 stores,
-                dcc.Store(id="theme-store", storage_type="local"),
+                # dcc.Store(id="theme-store", storage_type="local"),
                 dcc.Location(id="url"),
                 dmc.NotificationsProvider(
                     [

--- a/web/src/web/layout/header.py
+++ b/web/src/web/layout/header.py
@@ -1,5 +1,5 @@
 import dash_mantine_components as dmc
-from dash import Input, Output, State, clientside_callback
+from dash import Input, Output, clientside_callback  # State (used for color-scheme)
 from dash_iconify import DashIconify
 from web.config import get_settings
 
@@ -112,16 +112,16 @@ def create_header(nav_data: list | dict) -> dmc.Header:
                                     create_header_link(
                                         "carbon:settings", settings.baserow_public_url
                                     ),
-                                    dmc.ActionIcon(
-                                        DashIconify(
-                                            icon="radix-icons:blending-mode", width=22
-                                        ),
-                                        variant="outline",
-                                        radius=30,
-                                        size=36,
-                                        color="yellow",
-                                        id="color-scheme-toggle",
-                                    ),
+                                    # dmc.ActionIcon(
+                                    #     DashIconify(
+                                    #         icon="radix-icons:blending-mode", width=22
+                                    #     ),
+                                    #     variant="outline",
+                                    #     radius=30,
+                                    #     size=36,
+                                    #     color="yellow",
+                                    #     id="color-scheme-toggle",
+                                    # ),
                                     dmc.MediaQuery(
                                         dmc.ActionIcon(
                                             DashIconify(
@@ -145,28 +145,28 @@ def create_header(nav_data: list | dict) -> dmc.Header:
     )
 
 
-clientside_callback(
-    """ function(data) { return data } """,
-    Output("mantine-docs-theme-provider", "theme"),
-    Input("theme-store", "data"),
-)
+# clientside_callback(
+#     """ function(data) { return data } """,
+#     Output("mantine-docs-theme-provider", "theme"),
+#     Input("theme-store", "data"),
+# )
 
-clientside_callback(
-    """function(n_clicks, data) {
-        if (data) {
-            if (n_clicks) {
-                const scheme = data["colorScheme"] == "dark" ? "light" : "dark"
-                return { colorScheme: scheme }
-            }
-            return dash_clientside.no_update
-        } else {
-            return { colorScheme: "light" }
-        }
-    }""",
-    Output("theme-store", "data"),
-    Input("color-scheme-toggle", "n_clicks"),
-    State("theme-store", "data"),
-)
+# clientside_callback(
+#     """function(n_clicks, data) {
+#         if (data) {
+#             if (n_clicks) {
+#                 const scheme = data["colorScheme"] == "dark" ? "light" : "dark"
+#                 return { colorScheme: scheme }
+#             }
+#             return dash_clientside.no_update
+#         } else {
+#             return { colorScheme: "light" }
+#         }
+#     }""",
+#     Output("theme-store", "data"),
+#     Input("color-scheme-toggle", "n_clicks"),
+#     State("theme-store", "data"),
+# )
 
 # noinspection PyProtectedMember
 clientside_callback(


### PR DESCRIPTION
I don't think the colorScheme DarkMode currently works (#260) - this PR comments out the references I can see to it. 

If there's a label for #low-priority then this would fit very much under that. 