### PR TITLE
Add user and developer documentation re: HySys

### DIFF
--- a/docs/developer/infrastructure.qmd
+++ b/docs/developer/infrastructure.qmd
@@ -2,7 +2,9 @@
 title: HYLODE Infrastructure
 ---
 
-Our infrastructure is managed under the [HySys](https://github.com/HYLODE/HySys) repository which contains a series of _readme_ files. Setup and deployment of the various services is described [here](https://github.com/HYLODE/HySys/blob/main/hylode/README.md)
+Our infrastructure is managed under the [HySys](https://github.com/HYLODE/HySys) repository which contains a series of _readme_ files. Setup and deployment of the various services is described [here](https://github.com/HYLODE/HySys/blob/main/hylode/README.md).
+
+Detailed documentation for each major subcomponent of HySys is provided below:
 
 - [HyCastle - the _keeper_](https://github.com/HYLODE/HySys/tree/main/hylode/hycastle)
 - [HyCommand - the _controller_](https://github.com/HYLODE/HySys/tree/main/hylode/hycommand)
@@ -10,3 +12,7 @@ Our infrastructure is managed under the [HySys](https://github.com/HYLODE/HySys)
 - [HyGear - the _transformer_](https://github.com/HYLODE/HySys/tree/main/hylode/hygear)
 - [HyMind - the _laboratory_](https://github.com/HYLODE/HySys/tree/main/hylode/hymind)
 - [HyViz - the _monitor_](https://github.com/HYLODE/HySys/tree/main/hylode/hyviz)
+
+## Deployment locations
+
+Deployment information for the `prod` and `staging_red` HySys deployments such as host, directory location on the host and assigned ports can be found in the [HySys README.md](https://github.com/HYLODE/HySys/blob/main/hylode/README.md).

--- a/docs/user/user.qmd
+++ b/docs/user/user.qmd
@@ -2,6 +2,31 @@
 title: User guide for HYLODE
 ---
 
+# HySys
+Your first port of call for all questions HySys should be the [top-level repository documentation](https://github.com/HYLODE/HySys/blob/main/hylode/README.md). Some tips and tricks for particularly common patterns are given here.
 
+## Deployment
+Deployment instructions for a fresh installation of HySys are provided in the readme linked to above. To redeploy an already existing deployment on the NHS network:
+
+1. Navigate to the directory containing the checked out repository. Locations are provided [here](https://github.com/HYLODE/HySys/blob/main/hylode/README.md) for the `staging_red` and `prod` deployments.
+2. Navigate to the the `hylode/` directory (containing `docker-compose.yml`)
+3. From within a `tmux` or `screen` session, execute the `bin/up.sh` script to deploy most of the back-end HySys services
+    - you can execute this by running `./bin/up.sh` on the command line
+    - it's recommended to run this command inside a `tmux` or `screen` session
+
+This will redeploy all *non-interactive* services - everything but the HyMind `Lab` and `Field`.
+
+### Interactive service deployment
+To deploy the `HyMind Lab` and `HyMind Field` services, execute `./bin/interactive-up.sh`. Again, it's recommended that you do this within a `screen` or `tmux` session.
+
+## Taking services down
+To take down all running services - including interactive services described above:
+
+1. Navigate to the directory containing the checked out repository. Locations are provided [here](https://github.com/HYLODE/HySys/blob/main/hylode/README.md) for the `staging_red` and `prod` deployments.
+2. Navigate to the the `hylode/` directory (containing `docker-compose.yml`)
+3. Run `./bin/down.sh` from the command line
+    - Optionally provide the `--remove-orphans` flag to remove hanging containers and networks. This **will not** remove any associated docker volumes, so is safe from a data-loss perspective.
+
+## Please note
 - the application is only accessible from within the UCLH network
 - usernames and passwords are available after training from the development team

--- a/docs/user/user.qmd
+++ b/docs/user/user.qmd
@@ -27,6 +27,11 @@ To take down all running services - including interactive services described abo
 3. Run `./bin/down.sh` from the command line
     - Optionally provide the `--remove-orphans` flag to remove hanging containers and networks. This **will not** remove any associated docker volumes, so is safe from a data-loss perspective.
 
+### In-band predictions
+Current and past model predictions arising as a result of the HySys pipeline are written to corresponding tables within the `hymind` schema within the `hylode` database found in the `postgres` service of each environment.
+
+The latest predictions are available via the HyMind API REST endpoint. The [HySys](https://github.com/HYLODE/HySys/blob/main/hylode/README.md) documentation details the URL of the documentation of this API - look for `HYMIND_API_WEB_PORT`.
+
 ## Please note
 - the application is only accessible from within the UCLH network
 - usernames and passwords are available after training from the development team


### PR DESCRIPTION
Adds documentation for the developer and user better explaining how to perform some common tasks with HySys, or at least where to find the correct documentation.

In tandem with HYLODE/HySys#574 this closes #278 


Also closes #276 