### PR TITLE
Basic auth for the dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,7 @@ CELERY_DASH_RESULT_BACKEND=redis://localhost:6379/0
 WEB_CELERY_DASH_BROKER_URL=redis://localhost:6379/0
 WEB_CELERY_DASH_RESULT_BACKEND=redis://localhost:6379/0
 WEB_REDIS_CACHE=redis://localhost:6379/1
+
+# User/Password for basic login
+WEB_HYUI_USER=hylode
+WEB_HYUI_PASSWORD=hylode

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "Flask-Login == 0.6.2",
     "celery~=5.2.7",
     "dash-ag-grid ~= 2.0.0",
+    "dash-auth ~= 2.0.0",
     "dash-bootstrap-components >= 1.2.1",
     "dash-cytoscape >= 0.3.0",
     "dash-daq >= 0.5.0",

--- a/web/src/web/app.py
+++ b/web/src/web/app.py
@@ -3,6 +3,7 @@ from dash import CeleryManager
 from flask import Flask
 
 import web
+import dash_auth
 
 from web.celery import celery_app
 from web.celery_startup import run_startup_tasks
@@ -19,6 +20,13 @@ celery_manager = CeleryManager(celery_app)
 
 # run celery startup tasks
 run_startup_tasks()
+
+
+hyui_user = f"{get_settings().hyui_user}"
+hyui_password = f"{get_settings().hyui_password.get_secret_value()}"
+
+VALID_USERNAME_PASSWORD_PAIRS = {hyui_user: hyui_password}
+
 
 logger.info("Starting the Dash application")
 app = dash.Dash(
@@ -47,6 +55,8 @@ app = dash.Dash(
     ],
     index_string=web.INDEX_STRING,
 )
+
+auth = dash_auth.BasicAuth(app, VALID_USERNAME_PASSWORD_PAIRS)
 
 # Buld layout from page registry
 app.layout = create_appshell([dash.page_registry.values()])

--- a/web/src/web/config.py
+++ b/web/src/web/config.py
@@ -18,6 +18,9 @@ class Settings(BaseSettings):
     celery_dash_result_backend: AnyUrl
     redis_cache: AnyUrl
 
+    hyui_user: str
+    hyui_password: SecretStr
+
     slack_log_webhook: SecretStr
 
     class Config:


### PR DESCRIPTION
Adding basic auth as demonstrated in [the dash documentation](https://dash.plotly.com/authentication)

Closes #262 

Tested on GAE08: try this out for yourself on port 9902