### PR TITLE
Celery 

### DIFF
--- a/web/src/web/celery_tasks.py
+++ b/web/src/web/celery_tasks.py
@@ -13,7 +13,7 @@ from web.logger import logger
 
 @celery_app.task
 def get_response(
-    url: str, cache_key: str, params: Optional[int] = None, expires: int = 3600
+    url: str, cache_key: str, params: Optional[dict] = None, expires: int = 3600
 ) -> tuple[object, int]:
     """
     Get a response from a URL
@@ -31,7 +31,7 @@ def get_response(
         response = requests.get(url)
     else:
         logger.info(f"Fetching {url} - params {str(params)[:16]} ...")
-        response = requests.get(url, params=str(params))
+        response = requests.get(url, params=params)
 
     if response.status_code != 200:
         logger.error(f"Error fetching {url}: {response.status_code}")


### PR DESCRIPTION
Might be related to #300 – I was trying to at least stand up the docker containers on GAE and found this was causing the URL to be constructed wrong. An empty result was stored in the Redis cache for the census and therefore the pages were blank.

After this fix, the pages load but the discharge info requests from Baserow cause the pages to be slow to load, but I am testing this using the Baserow running on GAE07 while running HyUI on GAE08, so maybe it's mostly the transport time across the different machines.